### PR TITLE
Update dv_tabs.js

### DIFF
--- a/Source/dv_tabs.js
+++ b/Source/dv_tabs.js
@@ -47,6 +47,7 @@ function tab_setup( _P) {
      // attach onclick event
      var P = _P;
      _vli.addEvent( 'click', function( _e){
+       _e.stop()
        var xa = this.id.split( '_');
        if ( xa.length < 3) return;
        tab_activate( P, xa[ 1], xa[ 2]);


### PR DESCRIPTION
Added event.stop() function to prevent adding #anchor's to the URL/browsing history.
